### PR TITLE
Stop using openstruct

### DIFF
--- a/lib/file_validators.rb
+++ b/lib/file_validators.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'active_model'
-require 'ostruct'
 
 module FileValidators
   extend ActiveSupport::Autoload

--- a/lib/file_validators/validators/file_content_type_validator.rb
+++ b/lib/file_validators/validators/file_content_type_validator.rb
@@ -59,7 +59,7 @@ module ActiveModel
         if tool.present?
           FileValidators::MimeTypeAnalyzer.new(tool).call(value)
         else
-          value = OpenStruct.new(value) if value.is_a?(Hash)
+          value = Struct.new(value) if value.is_a?(Hash)
           value.content_type
         end
       end

--- a/lib/file_validators/validators/file_size_validator.rb
+++ b/lib/file_validators/validators/file_size_validator.rb
@@ -47,7 +47,7 @@ module ActiveModel
         value = JSON.parse(value) if value.is_a?(String)
         return [] unless value.present?
 
-        value = OpenStruct.new(value) if value.is_a?(Hash)
+        value = Struct.new(value) if value.is_a?(Hash)
 
         Array.wrap(value).reject(&:blank?)
       end


### PR DESCRIPTION
```
/opt/rubies/3.3.5/lib/ruby/3.3.0/bundled_gems.rb:75: warning: /opt/rubies/3.3.5/lib/ruby/3.3.0/ostruct.rb was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add ostruct to your Gemfile or gemspec to silence this warning.
Also please contact the author of file_validators-3.0.0 to request adding ostruct into its gemspec.
```